### PR TITLE
Fix: Filter out empty string properties in dataframe_to_entities

### DIFF
--- a/src/structify/resources/polars.py
+++ b/src/structify/resources/polars.py
@@ -1118,7 +1118,7 @@ def chunk_entities_for_parallel_add(
 def dataframe_to_entities(
     batch_df: pl.DataFrame, entity_type: str, column_schema: Dict[str, str], zero_ids: bool = False
 ) -> list[EntityParam]:
-    """Convert DataFrame rows to EntityParam objects, filtering out null values."""
+    """Convert DataFrame rows to EntityParam objects, filtering out null values and empty strings."""
     return [
         EntityParam(
             type=entity_type,
@@ -1126,7 +1126,7 @@ def dataframe_to_entities(
             properties={
                 prop_name: str(row[col_name])
                 for col_name, prop_name in column_schema.items()
-                if row[col_name] is not None
+                if row[col_name] is not None and str(row[col_name]).strip() != ""
             },
         )
         for i, row in enumerate(batch_df.to_dicts())


### PR DESCRIPTION
## Summary
- Fixes InternalServerError when enriching Polars dataframes containing empty string values
- Filters out both None values and empty strings when converting DataFrame rows to EntityParam objects

## Problem
The Rust API validation rejects empty string property values with a 'Property value is empty' error. When users try to enrich large Polars dataframes that contain empty string values, they encounter an InternalServerError.

## Solution
Updated the `dataframe_to_entities` function to filter out both:
1. `None` values (existing behavior)
2. Empty strings after stripping whitespace (new behavior)

This ensures that only non-empty property values are sent to the API, preventing validation errors.

## Test plan
- [ ] Test with a Polars dataframe containing empty string values
- [ ] Verify that enrichment operations no longer fail with "Property value is empty" error
- [ ] Confirm that valid string values are still properly processed

🤖 Generated with [Claude Code](https://claude.ai/code)