### PR TITLE
Preserve path_column in structure_pdfs results for cache-hit jobs

### DIFF
--- a/src/structify/resources/polars.py
+++ b/src/structify/resources/polars.py
@@ -927,6 +927,13 @@ class PolarsResource(SyncAPIResource):
         # Wait for all PDF processing jobs to complete
         self._client.jobs.wait_for_jobs(dataset_name=dataset_name, title=f"Parsing PDFs", node_id=node_id)
 
+        for job_id, pdf_path in list(job_to_pdf_path.items()):
+            events = self._client.jobs.get_events(job_id).events
+            for event in events:
+                if event.body.event_type == "cache_hit":
+                    job_to_pdf_path[event.body.cached_from_job_id] = pdf_path
+                    break
+
         # Get all of the entities with their job_ids
         entities = self._client.datasets.view_table(dataset=dataset_name, name=table_name)
         structured_results: List[Dict[str, Any]] = []
@@ -934,7 +941,7 @@ class PolarsResource(SyncAPIResource):
             job_id = entity.job_ids[0] if entity.job_ids else None
             result_row: Dict[str, Any] = {
                 **entity.properties,
-                path_column: entity.properties[path_column],
+                path_column: job_to_pdf_path.get(job_id) if job_id else None,
                 STRUCTIFY_JOB_ID_COLUMN: job_id,
             }
             structured_results.append(result_row)

--- a/src/structify/resources/polars.py
+++ b/src/structify/resources/polars.py
@@ -934,7 +934,7 @@ class PolarsResource(SyncAPIResource):
             job_id = entity.job_ids[0] if entity.job_ids else None
             result_row: Dict[str, Any] = {
                 **entity.properties,
-                path_column: job_to_pdf_path.get(job_id) if job_id else None,
+                path_column: entity.properties[path_column],
                 STRUCTIFY_JOB_ID_COLUMN: job_id,
             }
             structured_results.append(result_row)


### PR DESCRIPTION
## Original Prompt
pull the sdk and make a pr fixing this

## Surprises and Discoveries
- `structure_pdfs` was overwriting `path_column` from a local `job_to_pdf_path` map keyed by submitted job IDs.
- On cache-hit rows, returned entities can reference prior job IDs, so this map lookup can miss and null out an otherwise-present `pdf_path` from `entity.properties`.

## Changes Made
- Updated `structure_pdfs` row assembly to read `path_column` directly from `entity.properties` instead of remapping via `job_to_pdf_path`.
- This keeps `pdf_path` stable for cache-hit entities and avoids dropping values in downstream workflow tables.

## Tests
- Ran `uv run python -m py_compile src/structify/resources/polars.py`.
