### PR TITLE
Remove local model format validation in polars resource

### DIFF
--- a/src/structify/resources/polars.py
+++ b/src/structify/resources/polars.py
@@ -905,14 +905,6 @@ class PolarsResource(SyncAPIResource):
 
         node_id = get_node_id()
 
-        # Validate model format if provided as string
-        if isinstance(model, str):
-            parts = model.split(".", 1)
-            if len(parts) != 2:
-                raise ValueError(
-                    "model must be in format 'provider.model_name' (e.g. 'bedrock.claude-sonnet-4-bedrock')"
-                )
-
         instructions_list: list[str | None] = []
 
         if instructions is not None and not isinstance(instructions, str):
@@ -1070,13 +1062,6 @@ class PolarsResource(SyncAPIResource):
         )
 
         node_id = get_node_id()
-
-        if isinstance(model, str):
-            parts = model.split(".", 1)
-            if len(parts) != 2:
-                raise ValueError(
-                    "model must be in format 'provider.model_name' (e.g. 'bedrock.claude-sonnet-4-bedrock')"
-                )
 
         # Request cost confirmation before uploading
         if not request_cost_confirmation_if_needed(self._client, len(collected_df), "tag"):


### PR DESCRIPTION
### Motivation
- The client enforced a specific `model` string format (e.g. `provider.model_name`) in select Polars helpers, which causes valid server-accepted model identifiers to be rejected by the client.
- Drop the local shape/format validation so model values provided by callers are forwarded to the API server unchanged.

### Description
- Removed the client-side `model` format validation from `PolarsResource.structure_pdfs` so `model` is passed directly to `self._client.structure.pdf(...)` without enforcing `provider.model_name` parsing.
- Removed the client-side `model` format validation from `PolarsResource.tag` so `model` is passed directly to `self._client.entities.derive_all(...)` without local format checks.
- Changes are limited to `src/structify/resources/polars.py` and simply delete the early `ValueError` checks.

### Testing
- Ran `python -m py_compile src/structify/resources/polars.py`, which failed in this environment due to the repo `.python-version` pointing to an unavailable `3.9.18` (pyenv error).
- Ran `python3 -m py_compile src/structify/resources/polars.py`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d56a6ced1c83298e5ed3e15a1020a6)